### PR TITLE
Make `assertPossibleRetainCycle` more generic

### DIFF
--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Assertions/ModalDismissalRetainCycleAssertion.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Assertions/ModalDismissalRetainCycleAssertion.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-func assertPossibleRetainCycle(ofViewController viewController: UIViewController?) {
-    if viewController == nil { return }
+func assertPossibleRetainCycle(for object: AnyObject?) {
+    if object == nil { return }
     
     // Добавляем задержку в 1 секунду на всякий случай, чтобы точно дать UIKit'у очистить память.
     // Если даже через 1 секунду UIKit не очистил память от закрытого экрана, то, вероятно, он утек.
@@ -14,11 +14,11 @@ func assertPossibleRetainCycle(ofViewController viewController: UIViewController
     // разберется, что экран уже закрыт (через логику `isDescribingScreenThatWasAlreadyDismissedWithoutInvokingMarshroute`).
     // Однако, в этот момент сам модуль Shelf будет еще в памяти (UIKit его до сих пор не очистит, непонятно почему).
     // Поэтому даем UIKit'у время на очистку и откладываем проверку перед ассертом.
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak viewController] in
-        if let viewController {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak object] in
+        if let object {
             marshrouteAssertionFailure(
                 """
-                It looks like \(viewController as Any) did not deallocate due to some retain cycle!
+                It looks like \(object as Any) did not deallocate due to some retain cycle!
                 """
             )
         }

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Modal/Presentation/ModalPresentationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Modal/Presentation/ModalPresentationAnimationLaunchingContext.swift
@@ -26,7 +26,7 @@ public struct ModalPresentationAnimationLaunchingContext {
         }
         
         if sourceViewController?.presentedViewController == nil {
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalEndpointNavigation/Presentation/ModalEndpointNavigationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalEndpointNavigation/Presentation/ModalEndpointNavigationAnimationLaunchingContext.swift
@@ -27,7 +27,7 @@ public struct ModalEndpointNavigationPresentationAnimationLaunchingContext {
         }
         
         if sourceViewController?.presentedViewController == nil {
-            assertPossibleRetainCycle(ofViewController: targetNavigationController)
+            assertPossibleRetainCycle(for: targetNavigationController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalMasterDetail/Presentation/ModalMasterDetailPresentationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalMasterDetail/Presentation/ModalMasterDetailPresentationAnimationLaunchingContext.swift
@@ -26,7 +26,7 @@ public struct ModalMasterDetailPresentationAnimationLaunchingContext {
         }
         
         if sourceViewController?.presentedViewController == nil {
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalNavigation/Presentation/ModalNavigationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/ModalNavigation/Presentation/ModalNavigationAnimationLaunchingContext.swift
@@ -31,7 +31,7 @@ public struct ModalNavigationPresentationAnimationLaunchingContext {
         }
         
         if sourceViewController?.presentedViewController == nil {
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Navigation/Push/PushAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Navigation/Push/PushAnimationLaunchingContext.swift
@@ -32,7 +32,7 @@ public struct PushAnimationLaunchingContext {
             let targetViewController = targetViewController,
             !navigationController.viewControllers.contains(targetViewController)
         {
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Popover/Presentation/PopoverPresentationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/Popover/Presentation/PopoverPresentationAnimationLaunchingContext.swift
@@ -36,7 +36,7 @@ public struct PopoverPresentationAnimationLaunchingContext {
         }
         
         if popoverController?.isPopoverVisible != true { 
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         

--- a/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/PopoverNavigation/Presentation/PopoverNavigationPresentationAnimationLaunchingContext.swift
+++ b/Marshroute/Sources/Transitions/TransitionAnimationsLaunching/PopoverNavigation/Presentation/PopoverNavigationPresentationAnimationLaunchingContext.swift
@@ -41,7 +41,7 @@ public struct PopoverNavigationPresentationAnimationLaunchingContext {
         }
         
         if popoverController?.isPopoverVisible != true { 
-            assertPossibleRetainCycle(ofViewController: targetViewController)
+            assertPossibleRetainCycle(for: targetViewController)
             return true
         }
         


### PR DESCRIPTION
The project has an error at build time because of an implicit `UIKit` import in `ModalDismissalRetainCycleAssertion`
This PR makes interface `ModalDismissalRetainCycleAssertion` more generic, so it does not coupled with `UIKit` any more
<img width="1512" alt="Screenshot 2024-03-15 at 09 46 23" src="https://github.com/avito-tech/Marshroute/assets/939390/ecb54cb3-2454-4694-bbde-d1357f1468be">
